### PR TITLE
Agregando los atributos privados y cambio en cálculo del total

### DIFF
--- a/src/Library/Equipment.cs
+++ b/src/Library/Equipment.cs
@@ -8,6 +8,9 @@ namespace Full_GRASP_And_SOLID.Library
 {
     public class Equipment
     {
+        private string description;
+        private double hourlyCost;
+
         public Equipment(string description, double hourlyCost)
         {
             this.Description = description;

--- a/src/Library/Product.cs
+++ b/src/Library/Product.cs
@@ -8,6 +8,9 @@ namespace Full_GRASP_And_SOLID.Library
 {
     public class Product
     {
+        private string description;
+        private double unitCost;
+        
         public Product(string description, double unitCost)
         {
             this.Description = description;

--- a/src/Library/Recipe.cs
+++ b/src/Library/Recipe.cs
@@ -21,7 +21,7 @@ namespace Full_GRASP_And_SOLID.Library
     public class Recipe
     {
         private ArrayList steps = new ArrayList();
-
+        private Product finalProduct;
         public Product FinalProduct { get; set; }
 
         public void AddStep(Step step)
@@ -36,27 +36,32 @@ namespace Full_GRASP_And_SOLID.Library
 
         public void PrintRecipe()
         {
-            
+
             Console.WriteLine($"Receta de {this.FinalProduct.Description}:");
             foreach (Step step in this.steps)
             {
                 Console.WriteLine($"{step.Quantity} de '{step.Input.Description}' " +
                     $"usando '{step.Equipment.Description}' durante {step.Time}");
-                
+
             }
-            Console.WriteLine("el precio de produccion es " + GetProductionCost());
+            Console.WriteLine($"Costo total de producción: {this.GetProductionCost()}");
         }
-        
-        // Método para obtener el costo de producción.
+
+        /* Esta clase tiene toda la información necesaria para implementar la responsabilidad de calcular el costo total de producción
+        por lo tanto es la experta en información. Lo que estamos haciendo es aplicar el patrón experto.*/
+
         public double GetProductionCost()
-        {   
-            double costoFinal = 0;
-            
-            foreach(Step step in steps)
+        {
+            double costoInsumos = 0;
+            double costoEquipamiento = 0;
+
+            foreach (Step paso in steps)
             {
-                costoFinal += (step.Quantity/1000 * step.Input.UnitCost) + (step.Time/3600 * (step.Equipment.HourlyCost));
+                costoInsumos += paso.Input.UnitCost * paso.Quantity;
+                costoEquipamiento += paso.Equipment.HourlyCost * paso.Time;
             }
-            return costoFinal;
+
+            return costoInsumos + costoEquipamiento;
         }
     }
 }

--- a/src/Library/Step.cs
+++ b/src/Library/Step.cs
@@ -8,6 +8,11 @@ namespace Full_GRASP_And_SOLID.Library
 {
     public class Step
     {
+        private Product input;
+        private double quantity;
+        private int time;
+        private Equipment equipment;
+
         public Step(Product input, double quantity, Equipment equipment, int time)
         {
             this.Quantity = quantity;
@@ -23,6 +28,5 @@ namespace Full_GRASP_And_SOLID.Library
         public int Time { get; set; }
 
         public Equipment Equipment { get; set; }
-
     }
 }


### PR DESCRIPTION
Agregué a casi todas las clases lo de declarar los atributos como privados para que quede encapsulado. Porque estaban sólo los gets y sets públicos.
Y cambié la forma de escribir el cálculo, me parece que queda más claro así separado por costo de insumos y costos de equipamientos y sumarlos al final.
Yo creo que no es necesario dividirlo entre 3600 y entre 1000 porque estamos suponiendo cosas que no dice la letra. Creo que queda mejor costo*cantidad y costo por hora * tiempo de uso. Pero por supuesto que si les parece bien dejarlo tampoco tengo problema.